### PR TITLE
gitignore perl build artifacts and dists.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+Net-Netmask-*.tar.gz
+
+# See https://github.com/github/gitignore/blob/master/Perl.gitignore
+/blib/
+/.build/
+_build/
+cover_db/
+inc/
+Build
+!Build/
+Build.bat
+.last_cover_stats
+/Makefile
+/Makefile.old
+/MANIFEST.bak
+/META.yml
+/META.json
+/MYMETA.*
+nytprof.out
+/pm_to_blib
+*.o
+*.bs
+/_eumm/


### PR DESCRIPTION
This adds a .gitignore, ignoring standard perl build artifacts and the module's dist archives. It's based on the example at https://github.com/github/gitignore/blob/master/Perl.gitignore.