### PR TITLE
Improve test coverage

### DIFF
--- a/lib/Net/Netmask.pm
+++ b/lib/Net/Netmask.pm
@@ -74,7 +74,7 @@ sub new
 			$error = "illegal netmask: $mask";
 		}
 	} elsif (($net =~ m,^\d+\.\d+\.\d+\.\d+$,) &&
-		($mask =~ m,0x[a-z0-9]+,i)) 
+		($mask =~ m,0x[a-f0-9]+,i))
 	{
 		$base = $net;
 		my $imask = hex($mask);

--- a/lib/Net/Netmask.pm
+++ b/lib/Net/Netmask.pm
@@ -118,20 +118,20 @@ sub new
 
 	carp $error if $error && $debug;
 
-	$ibase = quad2int($base || 0) unless defined $ibase;
-	unless (defined($ibase) || defined($error)) {
-		$error = "could not parse $net";
-		$error .= " $mask" if $mask;
-	}
-	$ibase &= $imask[$bits]
-		if defined $ibase && defined $bits;
-
 	$bits = 0 unless $bits;
 	if ($bits > 32) { 
 		$error = "illegal number of bits: $bits"
 			unless $error;
 		$bits = 32;
 	}
+
+	$ibase = quad2int($base || 0) unless defined $ibase;
+	unless (defined($ibase) || defined($error)) {
+		$error = "could not parse $net";
+		$error .= " $mask" if $mask;
+	}
+	$ibase &= $imask[$bits]
+		if defined $ibase;
 
 	return bless { 
 		'IBASE' => $ibase,

--- a/t/badnets.t
+++ b/t/badnets.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-BEGIN { $| = 1; print "1..28\n";}
+BEGIN { $| = 1; print "1..52\n";}
 use Net::Netmask;
 $loaded = 1;
 print "ok 1\n";
@@ -62,6 +62,39 @@ test(26,Net::Netmask->new2('209.157.64.0   -   209.157.95.255'),
 # test ranges that are a power-of-two big, but are not legal blocks
 test(27,! Net::Netmask->new2('218.0.0.0 - 221.255.255.255'),
 	"could not find exact fit for 218.0.0.0 - 221.255.255.255");
-test(28,! Net::Netmask->new2('218.0.0.4 - 218.0.0.11'),
+test(28,scalar(Net::Netmask->errstr =~ /^could not find exact fit/),
+	"errstr mismatch");
+test(29,! Net::Netmask->new2('218.0.0.4 - 218.0.0.11'),
 	"could not find exact fit for 218.0.0.4 - 218.0.0.11");
+test(30,scalar(Net::Netmask->errstr =~ /^could not find exact fit/),
+	"errstr mismatch");
+
+# test some more bad nets/masks
+test(31,!defined(Net::Netmask->new2('10.10.10.10#256.0.0.0')),"bad mask byte");
+test(32,scalar(Net::Netmask->errstr =~ /^illegal hostmask:/),"errstr mismatch");
+test(33,!defined(Net::Netmask->new2('209.157.200.22','256.255.224.0')),
+	"bad mask");
+test(34,scalar(Net::Netmask->errstr =~ /^illegal netmask:/),"errstr mismatch");
+test(35,!defined(Net::Netmask->new2('10.10.10.10','0xF')),"bad mask");
+test(36,scalar(Net::Netmask->errstr =~ /^illegal netmask:/),"errstr mismatch");
+test(37,!defined(Net::Netmask->new2('209.200.70.33/33')), "bad mask");
+test(38,scalar(Net::Netmask->errstr =~ /^illegal number of bits:/),"errstr mismatch");
+test(39,!defined(Net::Netmask->new2('209.200.64.0-309.157.95.255')),
+	"bad mask byte");
+test(40,scalar(Net::Netmask->errstr =~ /^illegal dotted quad/),
+	"errstr mismatch");
+
+# test completely invalid args
+test(41,!defined(Net::Netmask->new2('foo')),"bad net");
+test(42,scalar(Net::Netmask->errstr =~ /^could not parse /),"errstr mismatch");
+test(43,!defined(Net::Netmask->new2('10.10.10.10','foo')),"bad mask");
+test(44,scalar(Net::Netmask->errstr =~ /^could not parse /),"errstr mismatch");
+test(45,!defined(Net::Netmask->new2('10.10.10','foo')),"bad mask");
+test(46,scalar(Net::Netmask->errstr =~ /^could not parse /),"errstr mismatch");
+test(47,!defined(Net::Netmask->new2('10.10','foo')),"bad mask");
+test(48,scalar(Net::Netmask->errstr =~ /^could not parse /),"errstr mismatch");
+test(49,!defined(Net::Netmask->new2('10','foo')),"bad mask");
+test(50,scalar(Net::Netmask->errstr =~ /^could not parse /),"errstr mismatch");
+test(51,!defined(Net::Netmask->new2('10.10.10.10','0xYYY')),"bad mask");
+test(52,scalar(Net::Netmask->errstr =~ /^could not parse/),"errstr mismatch");
 

--- a/t/netmasks.t
+++ b/t/netmasks.t
@@ -4,7 +4,7 @@ use Net::Netmask;
 use Net::Netmask qw(sameblock cmpblocks);
 use Carp;
 use Carp qw(verbose);
-use Test::More tests => 295;
+use Test::More tests => 304;
 
 #  addr			mask		base		newmask	     bits  mb
 my @rtests = qw(
@@ -93,7 +93,7 @@ $x = new Net::Netmask ('140.174.82.64/27');
 is(($x->inaddr())[1], 64);
 is(($x->inaddr())[2], 95);
 
-$x = new Net::Netmask ('default');
+$x = new Net::Netmask ('any');
 ok($x->size() == 4294967296);
 
 $x = new Net::Netmask ('209.157.64.0/27');
@@ -101,6 +101,10 @@ $x = new Net::Netmask ('209.157.64.0/27');
 is($y[0], '209.157.64.0');
 is($y[31], '209.157.64.31');
 ok(! defined($y[32]));
+@y = $x->enumerate(31);
+is($y[0], '209.157.64.0');
+is($y[15], '209.157.64.30');
+ok(! defined($y[16]));
 
 $x = new Net::Netmask ('10.2.0.16/19');
 @y = $x->enumerate();
@@ -157,6 +161,9 @@ is($newmask->nth(1),'192.168.1.1');
 is($newmask->nth(-1),'192.168.1.255');
 is($newmask->nth(-2),'192.168.1.254');
 is($newmask->nth(0),'192.168.1.0');
+is($newmask->nth(1,31),'192.168.1.2');
+is($newmask->nth(256),undef);
+is($newmask->nth(-257),undef);
 
 ok($newmask->match('192.168.1.1') == 1);
 ok($newmask->match('192.168.1.100') == 100);
@@ -241,6 +248,10 @@ sub fdel
 
 my (@c) = range2cidrlist("66.33.85.239", "66.33.85.240");
 my $dl = dlist(@c);
+ok($dl eq '66.33.85.239/32 66.33.85.240/32');
+
+(@c) = range2cidrlist("66.33.85.240", "66.33.85.239");
+$dl = dlist(@c);
 ok($dl eq '66.33.85.239/32 66.33.85.240/32');
 
 (@c) = range2cidrlist('216.240.32.128', '216.240.36.127');
@@ -589,6 +600,12 @@ ok(! defined(findNetblock("10.2.1.0", $table77)));
 	is("$obj2", '217.173.200.0/21');
 	ok(! $obj1->contains($obj2));
 	ok(! $obj2->contains($obj1));
+}
+
+{
+	my $obj1 = new2 Net::Netmask ('217.173.192.0/21');
+	ok($obj1->contains("217.173.192.0/24"));
+	ok(! $obj1->contains("217.173.200.0/21"));
 }
 
 {

--- a/t/split.t
+++ b/t/split.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -I. -w
 
 use Net::Netmask;
-use Test::More tests => 6;
+use Test::More tests => 7;
 
 #feel free to add a build requires of Test::Exception if that is okay with you.
 sub throws_ok(&$$) {
@@ -29,6 +29,11 @@ throws_ok
 	{ $cidr30->split(3) } 
 	qr/^Parts count must be a number of base 2. Got: 3/,
 	"Non base 2 split count errors.";
+
+throws_ok
+	{ $cidr30->split() }
+	qr/^Parts must be defined and greater than 0./,
+	"undef split throws error";
 
 throws_ok
 	{ $cidr30->split( 0 ) }


### PR DESCRIPTION
This PR adds additional tests, and improves overall test coverage from 88.8% to 93.3%.

There are two changes to the module itself, in response to specific warnings appearing when creating objects with particularly egregious arguments.

The first change removes the warning "Illegal hexadecimal digit 'Y' ignored" when passing a mask like '0xY', and ensures that only valid hex characters are allowed.

The second change removes the warning "Use of uninitialized value in bitwise and (&)", by ensuring that $bits is defined and valid before using it to modify $ibase.